### PR TITLE
feat(web): create page title component and login page

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host",
     "build": "tsc -b && vite build",
     "preview": "vite preview"
   },

--- a/apps/web/src/components/atoms/PageTitle/index.tsx
+++ b/apps/web/src/components/atoms/PageTitle/index.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import * as S from './styles';
+import { Props } from './types';
+
+const PageTitle: React.FC<Props> = ({ text }) => {
+  return <S.PageTitle>{text}</S.PageTitle>;
+};
+
+export default PageTitle;

--- a/apps/web/src/components/atoms/PageTitle/styles.ts
+++ b/apps/web/src/components/atoms/PageTitle/styles.ts
@@ -1,0 +1,9 @@
+import styled, { css } from 'styled-components';
+
+export const PageTitle = styled.p`
+  ${({ theme }) => css`
+    color: ${theme.colors.textPrimary};
+    font-size: ${theme.typography.sizes.xl};
+    margin-bottom: ${theme.spacing.xl};
+  `}
+`;

--- a/apps/web/src/components/atoms/PageTitle/types.ts
+++ b/apps/web/src/components/atoms/PageTitle/types.ts
@@ -1,0 +1,3 @@
+export type Props = {
+  text: string;
+};

--- a/apps/web/src/components/molecules/LoginForm/index.tsx
+++ b/apps/web/src/components/molecules/LoginForm/index.tsx
@@ -3,9 +3,9 @@ import { MdEmail } from 'react-icons/md';
 import { RiLockPasswordFill } from 'react-icons/ri';
 import { FaEyeSlash } from 'react-icons/fa';
 import { IoEyeSharp } from 'react-icons/io5';
-import { Input } from '../../Atoms/Input';
-import { Icon } from '../../Atoms/Icon';
-import { Button } from '../../Atoms/Button';
+import { Input } from '../../atoms/Input';
+import { Icon } from '../../atoms/Icon';
+import { Button } from '../../atoms/Button';
 import { PasswordInput, Props } from './types';
 import * as S from './styles';
 

--- a/apps/web/src/pages/Login/index.tsx
+++ b/apps/web/src/pages/Login/index.tsx
@@ -1,5 +1,15 @@
-const Login = () => {
-  return <div>Login page</div>;
+import React from 'react';
+import * as S from './styles';
+import PageTitle from '../../components/atoms/PageTitle';
+import { LoginForm } from '../../components/molecules/LoginForm';
+
+const Login: React.FC = () => {
+  return (
+    <S.Container>
+      <PageTitle text="Login" />
+      <LoginForm onSubmit={() => {}} />
+    </S.Container>
+  );
 };
 
 export default Login;

--- a/apps/web/src/pages/Login/styles.ts
+++ b/apps/web/src/pages/Login/styles.ts
@@ -1,0 +1,11 @@
+import styled, { css } from 'styled-components';
+
+export const Container = styled.div`
+  ${() => css`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 100vh;
+  `}
+`;


### PR DESCRIPTION
Create the page title component to be used on all pages that require a title. The login page with an authentication form was created